### PR TITLE
Allow encapsulation with both single and double quotes for version

### DIFF
--- a/lib/chef/knife/github_deploy.rb
+++ b/lib/chef/knife/github_deploy.rb
@@ -292,7 +292,7 @@ class Chef
           version = nil
           cpath = get_cookbook_path(@cookbook_name)
           File.foreach("#{cpath}/metadata.rb") do |line|
-              if line =~ /version.*"(.*)"/i
+              if line =~ /version.*['"](.*)['"]/i
                  version = $1
                  break
               end


### PR DESCRIPTION
This is a fix for issue #14 and allows the version to be recognized when encapsulated with either single or double quotes. 
