### PR TITLE
If it is an HTTPS url, leave it as is.

### DIFF
--- a/lib/chef/knife/github_repo_create.rb
+++ b/lib/chef/knife/github_repo_create.rb
@@ -256,8 +256,8 @@ module KnifeGithubRepoCreate
       else
 
         github_url = @github_url.gsub('http://', 'git://') if @github_url =~ /^http:\/\/.*$/
-        github_url = @github_url.gsub('https://', 'git://') if @github_url =~ /^https:\/\/.*$/
- 
+        github_url = @github_url if @github_url =~ /^https:\/\/.*$/
+
         template_path = File.join(github_url, template_org, "chef_template_#{type}.git") 
         shell_out!("git clone #{template_path} #{target}") # , :cwd => cookbook_path)
       end

--- a/lib/knife-github/version.rb
+++ b/lib/knife-github/version.rb
@@ -1,6 +1,6 @@
 module Knife
   module Github
-    VERSION = "0.1.7"
+    VERSION = "0.1.8"
     MAJOR, MINOR, TINY = VERSION.split('.')
   end
 end


### PR DESCRIPTION
 In some proxy environment, git protocol may not work, making git as default protocol breaks