### PR TITLE
Bugfix

### DIFF
--- a/lib/chef/knife/github_base.rb
+++ b/lib/chef/knife/github_base.rb
@@ -294,12 +294,20 @@ class Chef
 
           def get_cookbook_path(cookbook_name)
             cookbook_path = config[:cookbook_path] || Chef::Config[:cookbook_path]
+
             if cookbook_path.nil? || cookbook_path.empty?
               Chef::Log.error("Please specify a cookbook path")
               exit 1
+            else
+              if cookbook_path.is_a?(String)
+                cookbook_path = [ File.expand_path(cookbook_path) ]
+              elsif cookbook_path.is_a?(Array)
+                cookbook_path.map! { |path| File.expand_path(path) }
+              else
+                Chef::Log.error("Cookbook path must be either a string or array")
+                exit 1
+              end
             end
-
-            cookbook_path = [ cookbook_path ] if cookbook_path.is_a?(String)
 
             unless File.exists?(cookbook_path.first) && File.directory?(cookbook_path.first)
               Chef::Log.error("Cannot find the directory: #{cookbook_path.first}")

--- a/lib/chef/knife/github_repo_create.rb
+++ b/lib/chef/knife/github_repo_create.rb
@@ -17,6 +17,7 @@
 #
 
 require 'chef/knife'
+require 'etc'
 
 module KnifeGithubRepoCreate
   class GithubRepoCreate < Chef::Knife
@@ -246,14 +247,14 @@ module KnifeGithubRepoCreate
       return nil
     end
 
-    # Get the username from passwd file or git config
+    # Get the username from git config otherwise fall back to passwd file
     # @param nil
     def get_username()
-      username = ENV['USER']
-      passwd_user = %x(getent passwd #{username} | cut -d ':' -f 5).chomp
-      username = passwd_user if passwd_user
-      git_user_name = %x(git config user.name).strip
-      username = git_user_name if git_user_name
+      username_gitconfig = %x(git config user.name).strip
+      username_passwd    = Etc.getpwnam(Etc.getlogin).gecos.gsub(/ - SBP.*/,'')
+
+      username = username_gitconfig unless username_gitconfig.nil?
+      username = username_passwd if username.empty?
       username
     end
 

--- a/lib/chef/knife/github_repo_destroy.rb
+++ b/lib/chef/knife/github_repo_destroy.rb
@@ -17,7 +17,7 @@
 #
 
 require 'chef/knife'
-
+require 'etc'
 module KnifeGithubRepoDestroy
   class GithubRepoDestroy < Chef::Knife
     # Implements the knife github repo destroy function
@@ -164,14 +164,14 @@ module KnifeGithubRepoDestroy
       return nil
     end
 
-    # Get the username from passwd file or git config
+    # Get the username from git config otherwise fall back to passwd file
     # @param nil
     def get_username()
-      username = ENV['USER']
-      passwd_user = %x(getent passwd #{username} | cut -d ':' -f 5).chomp
-      username = passwd_user if passwd_user
-      git_user_name = %x(git config user.name).strip
-      username = git_user_name if git_user_name
+      username_gitconfig = %x(git config user.name).strip
+      username_passwd    = Etc.getpwnam(Etc.getlogin).gecos.gsub(/ - SBP.*/,'')
+
+      username = username_gitconfig unless username_gitconfig.nil?
+      username = username_passwd if username.empty?
       username
     end
 


### PR DESCRIPTION
* Sets git proxy if proxy option does not match current git proxy and will revert to previous git proxy config after git clone has completed.

* Uses Etc module instead of getent; getent doesn't exist in OS X and generates error.

* Removes end of line spaces.